### PR TITLE
Start Script: Add shebang

### DIFF
--- a/winezgui-start.sh
+++ b/winezgui-start.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 sudo ./setup -i ; winezgui


### PR DESCRIPTION
See also: #21
Resolves [SC2148](https://www.shellcheck.net/wiki/SC2148)
Analyzed with ShellCheck v0.10.0.

Adds a shebang to the beginning of the start script to point to Bash, as present in other scripts.

This is one PR in a series I plan to make implementing "ShellCheck-conformity" so-to-speak into the codebase, as per #21. I am planning to do this on a per-file basis for somewhat ease of review, and with a separate commit on each PR for each ShellCheck resolution.

This is just my style of doing things and please absolutely feel free to tell me if you'd prefer a different way.

Thanks! :-)