### PR TITLE
winezgui: Resolve ShellCheck warnings

### DIFF
--- a/bin/winezgui
+++ b/bin/winezgui
@@ -9,9 +9,9 @@ export EMAIL="fast.rizwaan@gmail.com"
 export COPYRIGHT="GNU General Public License (GPLv3+)"
 export WEBSITE="https://github.com/fastrizwaan/WineZGUI"
 # Variables
-HEADER="$(basename ${0})"
+HEADER="$(basename "${0}")"
 WINEZGUIDIR="$(realpath -m ~/.local/share/winezgui)"
-TEMPDIR="$(realpath -m ${WINEZGUIDIR}/tmp)"
+TEMPDIR="$(realpath -m "${WINEZGUIDIR}/tmp")"
 
 WBOOT_CMD="$(which wineboot) -i"
 ICOTOOL_CMD="$(which icotool)"
@@ -115,7 +115,7 @@ ZENITY_VERSION=$(${ZENITY_CMD} --version|cut -f1 -d ".")
 
 WineZGUI_Window() # Main WineZGUI application window function
 {
-  HEADER="$(basename ${0})"
+  HEADER="$(basename "${0}")"
   
   # For Zenity 4
   if [ "${ZENITY_VERSION}" -eq 4 ]; then

--- a/bin/winezgui
+++ b/bin/winezgui
@@ -9,9 +9,25 @@ export EMAIL="fast.rizwaan@gmail.com"
 export COPYRIGHT="GNU General Public License (GPLv3+)"
 export WEBSITE="https://github.com/fastrizwaan/WineZGUI"
 # Variables
+HEADER="$(basename ${0})"
+WINEZGUIDIR="$(realpath -m ~/.local/share/winezgui)"
+TEMPDIR="$(realpath -m ${WINEZGUIDIR}/tmp)"
+
+WBOOT_CMD="$(which wineboot) -i"
+ICOTOOL_CMD="$(which icotool)"
+WRESTOOL_CMD="$(which wrestool)"
+ZENITY_CMD="$(which zenity)"
+EXIFTOOL_CMD="$(which exiftool)"
+ZSTD_CMD="$(which zstd)"
+TAR_CMD="$(which tar)"
+WGET_CMD="$(which wget)"
+
+SYSTEM_WINE="$(which wine)"
+ARGV="$@"
+
 export DEBUG="Y"
 export PROCESSNAME="$0"
-export HEADER="$(basename ${0})" # for Terminal Messages
+export HEADER  # for Terminal Messages
 # These values will be assigned by Setup using sed command
 export APPNAME=WineZGUI   # Application Name
 export APPVERSION="1.00"
@@ -19,9 +35,8 @@ export APP_WITH_VER="${APPNAME}-${APPVERSION}" # Example: WineZGUI-0.88
 export INSTALL_PREFIX="/usr"
 export DATADIR=/usr/share/winezgui # scripts & data dir; /usr changes to prefix
 export INSTALL_TYPE="system"
-export WINEZGUIDIR="$(realpath -m ~/.local/share/winezgui)"
-export TEMPDIR="$(realpath -m ${WINEZGUIDIR}/tmp)"
-
+export WINEZGUIDIR
+export TEMPDIR
 export FLATPAK_NAME=""
 #/These values will be changed  by Setup using sed command
 export SETTINGS_FILE="${WINEZGUIDIR}/Settings.yml" # Settings file 
@@ -31,14 +46,15 @@ export RUNNERS_DIR="${WINEZGUIDIR}/Runners"        # Wine runners Directory
 # Commands used by WineZGUI and Scripts
 export UPDATE_ICON_CACHE="gtk-update-icon-cache -f -t ~/.local/share/icons 2>/dev/null"
 export UPDATE_DESKTOP_DATABASE="update-desktop-database"
-export WBOOT_CMD="$(which wineboot) -i" # will be overridden by winezgui-set-wine_cmd-runner-commands()
-export ICOTOOL_CMD="$(which icotool)"
-export WRESTOOL_CMD="$(which wrestool)"
-export ZENITY_CMD="$(which zenity)"
-export EXIFTOOL_CMD="$(which exiftool)"
-export ZSTD_CMD="$(which zstd)"
-export TAR_CMD="$(which tar)"
-export WGET_CMD="$(which wget)"
+export WBOOT_CMD # will be overridden by winezgui-set-wine_cmd-runner-commands()
+export ICOTOOL_CMD
+export WRESTOOL_CMD
+export ZENITY_CMD
+export EXIFTOOL_CMD
+export ZSTD_CMD
+export TAR_CMD
+export WGET_CMD
+export SYSTEM_WINE
 # LD_LIBRARY_PATH
 if [ -z "${LD_LIBRARY_PATH}" ]; then
 LD_LIBRARY_PATH+="/lib:/lib32:/lib64"; fi
@@ -54,9 +70,8 @@ LD_LIBRARY_PATH+="/usr/lib/i386-linux-gnu/wine:"
 LD_LIBRARY_PATH+="$(pwd)"
 export LD_LIBRARY_PATH
 export PATH="${PATH}:/bin:/usr/bin:/usr/local/bin:/app/bin"
-export ARGV="$@"
+export ARGV
 
-export SYSTEM_WINE="$(which wine)"
 echo "SYSTEM_WINE=${SYSTEM_WINE}"
 
 # SOURCE function uses source command and try to required scripts in both DATADIR or SCRIPTDIR
@@ -69,8 +84,9 @@ SOURCE "winezgui-dbug"
 SOURCE "winezgui-set-wine_cmd-runner-commands"
 winezgui-set-wine_cmd-runner-commands
 
+APPLICATIONSDIR="$(realpath -m ~/.local/share/applications)"
 export ABOUTFILE="${WINEZGUIDIR}/About.yml"
-export APPLICATIONSDIR="$(realpath -m ~/.local/share/applications)"
+export APPLICATIONSDIR
 
 # Shortcuts (.desktop files) will be installed in APPLICATIONSDIR
 # prefixed with shortcut names to manage winezgui specific shortcuts

--- a/bin/winezgui
+++ b/bin/winezgui
@@ -23,7 +23,7 @@ TAR_CMD="$(which tar)"
 WGET_CMD="$(which wget)"
 
 SYSTEM_WINE="$(which wine)"
-ARGV="$@"
+ARGV=("$@")
 
 export DEBUG="Y"
 export PROCESSNAME="$0"

--- a/bin/winezgui
+++ b/bin/winezgui
@@ -4,6 +4,10 @@
 # URL: https://github.com/fastrizwaan/WineZGUI
 # winezgui main program to run or create a wine prefix for a selected exe
 # ============================================================================ #
+
+## ShellCheck can't read dynamic paths from `source`, so ignore them (SC1090/SC1091)
+# shellcheck source=/dev/null
+
 export AUTHOR="Mohammed Asif Ali Rizvan"
 export EMAIL="fast.rizwaan@gmail.com"
 export COPYRIGHT="GNU General Public License (GPLv3+)"

--- a/resources/modules/winezgui-cli-arguments
+++ b/resources/modules/winezgui-cli-arguments
@@ -7,7 +7,7 @@ winezgui-cli-arguments()
   HEADER="$(basename ${0}): ${FUNCNAME[0]}"
   dbug "I: ${HEADER}: started"
 
-  for i in "${ARGV}"; do
+  for i in "${ARGV[@]}"; do
      case ${i} in
      -v|--version) echo "${APPVERSION}"; exit; ;;
      -h|--help) SOURCE "winezgui-show-help; winezgui-show-help; exit; ;;"


### PR DESCRIPTION
See also: #21.
Resolves [SC2155](https://www.shellcheck.net/wiki/SC2155), [SC2086](https://www.shellcheck.net/wiki/SC2086), [SC2124](https://www.shellcheck.net/wiki/SC2124), and [SC1090](https://www.shellcheck.net/wiki/SC1090)/[SC1091](https://www.shellcheck.net/wiki/SC1091) for the `bin/winezgui` script.
Analyzed with ShellCheck v0.10.0.

This PR resolves ShellCheck analysis information/warnings. You can read more about them on the respective linked ShellCheck wiki pages, but I'll give a bit of background as well.
- **SC2155**: Instead of using `export VARNAME="$(mycmd)"`, we assign to a variable first and then export. This, to my understanding, basically makes sure we're using the value returned from the "subshell"(?).
    - For stylistic reasons, I moved these declarations to be above the `export`s, but this is not mandatory.
- **SC2086**: It's generally good scripting practice to quote strings to avoid them being split at unintentional points. This is done using the `IFS` separator, which I believe is an internal shell variable telling the shell how to split variables. By quoting we can be explicit that we don't want them split.
- **SC2124**: This one I think is an important one to fix. Basically, `ARGV` as it is being used in the code right now is just a string, when `ARGV` is supposed to be an array (in this case, of arguments that the script was called with). To fix this, the simplest approach for how `ARGV` is used around the code is to just wrap it in an array. This way, each element in `$@` will be inserted into an array and thus can be used as such.
    - Fixing this required changing how `ARGV` was used in `winezgui-cli-arguments` (the only place that currently uses it, from a search), because the behaviour became fundamentally different. The code before this change was just iterating over the string `ARGV` once and I believe just checking for string contents in the `case`, but I am not 100% sure. For what `ARGV` is used for currently in this file it probably would only ever only get one argument, it exits after it finds one argument match, so it would never run multiple anyway.
- **SC1090**/**SC1091**: ShellCheck can't analyze files using `source` with dynamic paths, which is what both of these warnings relate to. The general guidance is to simply ignore them if you don't care, which is exactly what I have done by adding the directive to the top of `winezgui` to tell ShellCheck to ignore this directive for this file.
    - Note that it is only for this file, other files may show this warning and can be silenced in the same way, it just has to be done on a per-file basis. You _can_ optionally add it to a `.shellcheckrc`, and I believe you can tell ShellCheck where to find that file with a directive afaik (so you could have a per-project `.shellcheckrc`), but I think that's excessive. There may be cases when `source` is used that ShellCheck can analyze, so ignoring per-file and on a case-by-case basis is safest in my mind.

<hr>

I did some quick regression-testing, but as I am new to the project, _please_ review thoroughly and let me know if I broke something.

This PR has been broken out into multiple commits, with each commit addressing a specific ShellCheck warning. I hope this aids in review :-)

Thanks!