### PR TITLE
check-variable: Refactor & ShellCheck

### DIFF
--- a/resources/modules/check-variable
+++ b/resources/modules/check-variable
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 #check-variable
 check-variable()
 {

--- a/resources/modules/check-variable
+++ b/resources/modules/check-variable
@@ -4,17 +4,18 @@
 check-variable()
 {
   if [ $# -lt 2 ]; then 
-	echo "need 2 arguments, filename and variable to test"
+    echo "need 2 arguments, filename and variable to test"
+    return
   fi
 
-  if [ ! -z "${!2}" ]; then
-       if [ "${DEBUG}" = "Y" ]; then
-            echo "Defined: $2=${!2}"
-       else
-            echo -n "."
-       fi
+  if [ -z "${!2}" ]; then
+    echo "Error $2 not defined in $1"
+    return
+  fi
+
+  if [ "${DEBUG}" = "Y" ]; then
+    echo "Defined: $2=${!2}"
   else
-       echo "Error $2 not defined in $1"
+    echo -n "."
   fi
-
 }


### PR DESCRIPTION
See also: #21
Resolves [SC2148](https://www.shellcheck.net/wiki/SC2148) and [SC2236](https://www.shellcheck.net/wiki/SC2236) through a refactor.

This PR does a refactor to the `check-variable` function. It adds a shebang, and I think I've bored you enough with repeating that over and over :wink: 

When resolving SC2236, I noticed there is some room for improvement with how the function is laid out. SC2236 says to use `-n` instead of `! -z"`. If we read `-n` as "defined" and "-z" as blank, then "defined" and "not blank" in this context mean the same thing. At first, I simply changed the code to use `-n`, but I noticed that the nested logic is a bit ugly. I have fallen victim to this many times and have recently in Bash trying to move towards returning early from functions.

So the function has now been changed to say:
- If the length of the given arguments is less than 2, don't continue with the function
- If the 2nd argument is not defined, don't continue with the function

If we make it past these checks, then we can assume from this point onwards in the function that we have all the values we need to continue.

This seems to work but please test and ensure I didn't cause any regressions.

This PR has changed the indentation around the file it seems, sorry. Let me know what the standard indentation should be and I will adjust and follow it.

Thanks!