### PR TITLE
script-about: Resolve ShellCheck Warnings

### DIFF
--- a/resources/modules/script-about
+++ b/resources/modules/script-about
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Show About
 # Steps
 # 1. Format yml data

--- a/resources/modules/script-about
+++ b/resources/modules/script-about
@@ -14,8 +14,8 @@ script-about()
   
   unset TEXT TEXT1
   # Replace full home path with tilde to save space. Format labels upto : with monospace and bold text and small text
-  TEXT1="$(while read -r line; do echo $line|sed "s|:$HOME|:~|g"|sed '0,/:/{s/:/ \`: /}'|sed -e 's/$/XX/g'|sed 's/^/<tt><b>/g'|sed 's/`:/<\/b>`:<small>/g'; done <  ${INFOFILE})"
-  TEXT="$(echo $TEXT1|sed -e 's/XX /<\/small><\/tt>\n/g'|sed -e 's/XX/<\/small><\/tt>\n/g'|column -t -s '\`')"
+  TEXT1="$(while read -r line; do echo "$line"|sed "s|:$HOME|:~|g"|sed '0,/:/{s/:/ \`: /}'|sed -e 's/$/XX/g'|sed 's/^/<tt><b>/g'|sed 's/`:/<\/b>`:<small>/g'; done <  "${INFOFILE}")"
+  TEXT="$(echo "$TEXT1"|sed -e 's/XX /<\/small><\/tt>\n/g'|sed -e 's/XX/<\/small><\/tt>\n/g'|column -t -s '\`')"
 
 
   ${ZENITY_CMD} --info --no-wrap --text "${TEXT}"

--- a/resources/modules/script-about
+++ b/resources/modules/script-about
@@ -14,7 +14,7 @@ script-about()
   
   unset TEXT TEXT1
   # Replace full home path with tilde to save space. Format labels upto : with monospace and bold text and small text
-  TEXT1="$(while read -r line; do echo "$line"|sed "s|:$HOME|:~|g"|sed '0,/:/{s/:/ \`: /}'|sed -e 's/$/XX/g'|sed 's/^/<tt><b>/g'|sed 's/`:/<\/b>`:<small>/g'; done <  "${INFOFILE}")"
+  TEXT1="$(while read -r line; do echo "$line"|sed "s|:$HOME|:~|g"|sed '0,/:/{s/:/ \`: /}'|sed -e 's/$/XX/g'|sed 's/^/<tt><b>/g'|sed "s/\`:/<\/b>\`:<small>/g"; done <  "${INFOFILE}")"
   TEXT="$(echo "$TEXT1"|sed -e 's/XX /<\/small><\/tt>\n/g'|sed -e 's/XX/<\/small><\/tt>\n/g'|column -t -s '\`')"
 
 


### PR DESCRIPTION
See also: #21
Resolves [SC2148](https://www.shellcheck.net/wiki/SC2148) and [SC2086](https://www.shellcheck.net/wiki/SC2086), [SC2016](https://www.shellcheck.net/wiki/SC2016)

This PR resolves various ShellCheck warnings in `script-about`. As usual, adds a shebang to resolve SC2148. It also fixes some string usage by quoting them to resolve SC2086.

The tricky one in this PR is SC2016, which warns that using an expansion in single-quoted expressions won't expand them (i.e. `echo ''$PATH'` would just return `$PATH`, not the result of the variable). This was a bit strange to me, because I didn't understand what expansion ShellCheck was referring to, so I wasn't sure what expansion it was warning about.

It turns out there's a legacy syntax where you can use two backticks like this ` `` ` in place of `$()`. Very unusual, and if you do actually use this syntax, ShellCheck warns you about this with [SC2006](https://www.shellcheck.net/wiki/SC2006).

ShellCheck is interpreting this `sed` expression as an unexpanded command using that backtick syntax syntax: `sed 's/`:/<\/b>`:<small>/g'`. It is a false-positive because this is matching some markup. Someone had a similar issue and reported it to ShellCheck: koalaman/shellcheck#2277

It is possible to ignore this by adding an ignore directive above the line, like this: `# shellcheck disable=SC2016`, and indeed that's what the user in the linked issue ended up doing. I did this at first, but opted to fix this by using double-quotes for that sed expression. The reason being:
1. It's a short expression, the user did say it adds more visual noise and I agree, but in this case it is fine. If we were doing this kind of thing in multiple places with a more complex pattern, it would probably be more worthwhile ignoring it for readability. But here, I think fixing it is trivial.
2. Ignoring it is a very "blanket" approach, and because this has multiple chained seds, it may not be clear which part this directive is referring to.
3. The backticks here, unlike in the linked issue, are from different parts of the pattern. We aren't matching two backticks in the same part of the pattern, we're matching a different set of backticks that are not correlated. Therefore it could be argued that it is more visually clear to escape them, rather than adding more noise.

But, if you would prefer to stick with single-quotes and disable the warning, that also works (although in that case, a comment explaining the rationale for the ignore might be helpful).

Thanks!