### PR TITLE
script-backup: Resolve ShellCheck Warnings

### DIFF
--- a/resources/modules/script-backup
+++ b/resources/modules/script-backup
@@ -35,7 +35,7 @@ script-backup()
 
   # PREFIX_SIZE_IN_BYTES is used externally (such as by script-backup-prefix and script-backup-bundle), so ignore SC2034
   # shellcheck disable=SC2034
-  PREFIX_SIZE_IN_BYTES=$(echo ${PREFIX_SIZE_IN_HF}|cut -f1 -d " "   \
+  PREFIX_SIZE_IN_BYTES=$(echo "${PREFIX_SIZE_IN_HF}"|cut -f1 -d " "   \
                                                   |numfmt --from iec)
   dbug "I: ${HEADER}: Prefix = ${PREFIXDIR}"
   dbug "I: ${HEADER}: Prefix size = ${PREFIX_SIZE_IN_HF}"

--- a/resources/modules/script-backup
+++ b/resources/modules/script-backup
@@ -17,6 +17,9 @@ script-backup()
   unset RESPONSE
   export SHORT_FLATPAK_NAME="${FLATPAK_NAME##*.}"
   # Using Date as part of wzt backup filename
+  #
+  # DATE is used externally (such as by script-backup-prefix and script-backup-bundle), so ignore SC2034
+  # shellcheck disable=SC2034
   DATE=$(date +%F_%H%M)
 
   # 0. Get disk usage of prefix
@@ -30,6 +33,8 @@ script-backup()
        echo "-------------------- Error --------------------------"
   fi
 
+  # PREFIX_SIZE_IN_BYTES is used externally (such as by script-backup-prefix and script-backup-bundle), so ignore SC2034
+  # shellcheck disable=SC2034
   PREFIX_SIZE_IN_BYTES=$(echo ${PREFIX_SIZE_IN_HF}|cut -f1 -d " "   \
                                                   |numfmt --from iec)
   dbug "I: ${HEADER}: Prefix = ${PREFIXDIR}"


### PR DESCRIPTION
See also: #21
Resolves [SC2086](https://www.shellcheck.net/wiki/SC2086)
Disables [SC2034](https://www.shellcheck.net/wiki/SC2034)

This PR resolves SC2086 warnings (double quote to prevent globbing) in `script-backup`.

It also disables SC2034 warnings, which warn when a variable appears unused. The two variables it warns about are `DATE` and `PREFIX_SIZE_IN_BYTES`. These variables are unused in the script file but are used by the scripts this file calls, such as `script-backup-prefix` and `script-backup-bundle`. From glacning at the code, my assumption is that the main functions in these two files are only meant to be called from `script-backup`, which means it is safe to assume that `DATE` and `PREFIX_SIZE_IN_BYTES` will always be set. Therefore I opted to simply disable this ShellCheck warning, because it's not helpful in this instance.

There could be a case for more safety around ensuring `DATE` is specified, or perhaps calculating these values in the respective script files, but I think if it ain't broke, don't fix it :-)

Short fix this time around. Thanks!